### PR TITLE
Drop phpdoc template parameter as it cannot be not used

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -40,10 +40,7 @@ abstract class Option
     /**
      * Unwraps a result, yielding the content of a Some.
      *
-     * @template X as Exception
-     *
      * @param Exception $msg
-     * @psalm-param X&Exception $msg
      * @return mixed
      * @psalm-return T
      * @throws Exception the message if the value is a None.

--- a/src/Option/None.php
+++ b/src/Option/None.php
@@ -63,10 +63,7 @@ class None extends Option
     /**
      * Unwraps a result, yielding the content of a Some.
      *
-     * @template X as Exception
-     *
      * @param Exception $msg
-     * @psalm-param X&Exception $msg
      * @return void
      * @psalm-return never-return
      * @throws Exception the message if the value is a None.


### PR DESCRIPTION
Psalm doesn't provide support use it in something like `@psalm-throws`

Fixes #5