### PR TITLE
feat!: `Option#iter(): array` -> `Option#iter(): iterable`

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -135,9 +135,9 @@ abstract class Option
      * Returns an iterator over the possibly contained value.
      * The iterator yields one value if the result is Some, otherwise none.
      *
-     * @return list<T>
+     * @return iterable<int, T>
      */
-    abstract public function iter(): array;
+    abstract public function iter(): iterable;
 
     /**
      * Returns None if the option is None, otherwise returns optb.

--- a/src/Option/None.php
+++ b/src/Option/None.php
@@ -102,7 +102,7 @@ class None extends Option
         return new Err($err(...$this->pass), ...$this->pass);
     }
 
-    public function iter(): array
+    public function iter(): iterable
     {
         return [];
     }

--- a/src/Option/Some.php
+++ b/src/Option/Some.php
@@ -111,7 +111,7 @@ class Some extends Option
         return new Ok($this->value, ...$this->pass);
     }
 
-    public function iter(): array
+    public function iter(): iterable
     {
         return [$this->value];
     }


### PR DESCRIPTION
semantically more correct